### PR TITLE
Implement scaffolding for kind checking

### DIFF
--- a/src/Context.ml
+++ b/src/Context.ml
@@ -39,7 +39,7 @@ let rec apply (context : t) (t : Type.t) : Type.t =
      in
      solved_type
   | Forall (a, k, t) ->
-     Forall (a, k, apply context t)
+     Forall (a, Option.map ~f:(apply context) k, apply context t)
   | Apply (t1, t2) ->
      Apply (apply context t1, apply context t2)
   | KindApply (t1, t2) ->

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -458,7 +458,7 @@ let rec check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) : (Context.t,
       ) ->
      Ok gamma
   | Constructor _, _ ->
-     raise (Failure "Kind checking failed for arbitrary constructors.")
+     Error (FailedKindChecking (_T, _K))
   | _, Forall (a, _, _A) ->
      let a' = fresh_name () in
      scoped gamma (Quantified a')

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -43,8 +43,12 @@ let rec well_formed_type (context : Context.t) (t : Type.t) : (unit, e) Result.t
        | Some _ -> Ok ()
        | None -> Error (IllFormedType t)
      )
-  | Forall (a, _, t) ->
-     well_formed_type (Quantified a :: context) t
+  | Forall (a, k, t) ->
+     let* () = well_formed_type (Quantified a :: context) t in
+     ( match k with
+       | Some k -> well_formed_type context k
+       | None -> Ok ()
+     )
   | Apply (t1, t2) | KindApply (t1, t2) | Annotate (t1, t2) ->
      let* _ = well_formed_type context t1
      and* _ = well_formed_type context t2

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -82,10 +82,15 @@ let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) : (Context.t, e)
          && Type.equal t_function t_function2 ->
      let* theta = subtype gamma a2 a1 in
      subtype theta (Context.apply theta b1) (Context.apply theta b2)
-  | _, Forall (b, _, _B) ->
+  | _, Forall (b, k, _B) ->
      let b' = fresh_name () in
-     scoped gamma (Quantified b')
-       (function gamma -> subtype gamma _A (Type.substitute b (Variable b') _B))
+     let _T =
+       match k with
+       | Some k -> Annotate (Unsolved b', k)
+       | None -> Unsolved b'
+     in
+     scoped_unsolved gamma b'
+       (function gamma -> subtype gamma _A (Type.substitute b _T _B))
   | Forall (a, k, _A), _ ->
      let a' = fresh_name () in
      let _T =

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -456,7 +456,7 @@ and check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) : (Context.t, e) 
       ) ->
      Ok gamma
   | Constructor _, _ ->
-     Error (FailedKindChecking (_T, _K))
+     raise (Failure "todo: arbitrary constructors should look up the environment")
   | _, Forall (a, _, _A) ->
      let a' = fresh_name () in
      scoped gamma (Quantified a')

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -86,10 +86,15 @@ let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) : (Context.t, e)
      let b' = fresh_name () in
      scoped gamma (Quantified b')
        (function gamma -> subtype gamma _A (Type.substitute b (Variable b') _B))
-  | Forall (a, _, _A), _ ->
+  | Forall (a, k, _A), _ ->
      let a' = fresh_name () in
+     let _T =
+       match k with
+       | Some k -> Annotate (Unsolved a', k)
+       | None -> Unsolved a'
+     in
      scoped_unsolved gamma a'
-       (function gamma -> subtype gamma (Type.substitute a (Unsolved a') _A) _B)
+       (function gamma -> subtype gamma (Type.substitute a _T _A) _B)
   | Unsolved a, _
        when Context.mem gamma (Unsolved a)
          && not (Set.mem (Type.free_type_variables _B) a) ->

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -184,22 +184,11 @@ and instantiateLeft (gamma : Context.t) (a : string) (_A : Type.t) : (Context.t,
        instantiateLeft gamma a' _A
      in
      instantiateLeft theta b' (Context.apply theta _B)
-  | KindApply (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Type.KindApply (Type.Unsolved a', Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateLeft gamma a' _A
-     in
-     instantiateLeft theta b' (Context.apply theta _B)
+  | KindApply (_, _) ->
+     (* KindApply isn't user-facing, so we shouldn't ever handle it when
+        performing instantiation.
+      *)
+     raise (Failure "instantiateLeft: called with KindApply")
   | Annotate (_A, _B) ->
      let a' = fresh_name () in
      let b' = fresh_name () in
@@ -283,22 +272,11 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) : (Context.t
        instantiateRight gamma _A a'
      in
      instantiateRight theta (Context.apply theta _B) b'
-  | KindApply (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Type.KindApply (Type.Unsolved a', Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateRight gamma _A a'
-     in
-     instantiateRight theta (Context.apply theta _B) b'
+  | KindApply (_, _) ->
+     (* KindApply isn't user-facing, so we shouldn't ever handle it when
+        performing instantiation.
+      *)
+     raise (Failure "instantiateRight: called with KindApply")
   | Annotate (_A, _B) ->
      let a' = fresh_name () in
      let b' = fresh_name () in

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -480,8 +480,8 @@ and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) resul
      let a' = fresh_name () in
      infer_kind (Unsolved a' :: gamma) (Type.substitute a (Unsolved a') _A)
   | Unsolved u ->
-     Ok (Unsolved u :: gamma, _T)
-     (* raise (Failure "Cannot synthesize unknowns in kinds.") *)
+     let u' = fresh_name () in
+     Ok (Unsolved u' :: gamma, (Type.substitute u (Unsolved u') _T))
   | Variable v ->
      let find_variable : Element.t -> Type.t option = function
        | Variable (v', t) when String.equal v v' -> Some t

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -521,9 +521,14 @@ and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) resul
 and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
   let open Primitives in
   match _K with
-  | Forall (a, _, _K) ->
+  | Forall (a, k, _K) ->
      let a' = fresh_name () in
-     infer_apply_kind (Unsolved a' :: gamma) (Type.substitute a (Unsolved a') _K) _X
+     let _T =
+       match k with
+       | Some k -> Annotate (Unsolved a', k)
+       | None -> Unsolved a'
+     in
+     infer_apply_kind (Unsolved a' :: gamma) (Type.substitute a _T _K) _X
   | Unsolved a ->
      let a' = fresh_name () in
      let b' = fresh_name () in

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -481,9 +481,15 @@ and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) resul
      let* gamma = check_kind gamma _A t_type in
      let* gamma = check_kind gamma _B t_type in
      Ok (gamma, t_type)
-  | Forall (a, _, _A) ->
+  | Forall (a, k, _A) ->
      let a' = fresh_name () in
-     infer_kind (Unsolved a' :: gamma) (Type.substitute a (Unsolved a') _A)
+     let _T =
+       match k with
+       | Some k -> Annotate (Unsolved a', k)
+       | None -> Unsolved a'
+     in
+     let* (gamma, _K) = infer_kind (Unsolved a' :: gamma) (Type.substitute a _T _A)
+     in Ok (Context.discard_up_to (Unsolved a') gamma, _K)
   | Unsolved u ->
      let u' = fresh_name () in
      Ok (Unsolved u' :: gamma, (Type.substitute u (Unsolved u') _T))

--- a/src/Type.ml
+++ b/src/Type.ml
@@ -73,6 +73,12 @@ module Primitives = struct
   let t_array = Constructor "Array"
 
   let t_function = Constructor "Function"
+
+  let is_primitive_type n =
+    List.mem [t_type;t_char;t_string;t_int;t_float] n ~equal:equal
+
+  let is_primitive_type_type n =
+    List.mem [t_array] n ~equal:equal
 end
 
 module Sugar = struct


### PR DESCRIPTION
This implements the initial scaffolding needed for kind checking. I'd like to have this merged into main in order to be able to work on other internal issues in the compiler such as using explicit mutable state for the context.