### PR TITLE
Make bidirectional typing aware of kinds

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,7 @@
+break-cases = fit
+if-then-else = keyword-first
+line-endings = lf
+margin = 80
+parse-docstrings = true
+profile = ocamlformat
+wrap-comments = true

--- a/src/Context.ml
+++ b/src/Context.ml
@@ -4,7 +4,7 @@ open Core_kernel
 module Element = struct
   type t =
     | Variable of string * Type.t
-    | Quantified of string
+    | Quantified of string * Type.t option
     | Unsolved of string
     | Solved of string * Type.t
     | Marker of string

--- a/src/Context.ml
+++ b/src/Context.ml
@@ -13,7 +13,9 @@ end
 
 type t = Element.t list
 
-type e = FailedToBreakApart [@@deriving eq]
+module Error = struct
+  type t = FailedToBreakApart [@@deriving eq]
+end
 
 let rec apply (context : t) (t : Type.t) : Type.t =
   let open Type in
@@ -60,10 +62,11 @@ let discard_up_to (element : Element.t) (context : t) : t =
   in
   aux context
 
-let break_apart_at (element : Element.t) (context : t) : (t * t, e) Result.t =
+let break_apart_at (element : Element.t) (context : t) : (t * t, Error.t) result
+    =
   let rec aux collected = function
     | [] ->
-        Error FailedToBreakApart
+        Error Error.FailedToBreakApart
     | current :: rest ->
         if Element.equal element current then Ok (List.rev collected, rest)
         else aux (current :: collected) rest

--- a/src/Context.ml
+++ b/src/Context.ml
@@ -8,66 +8,64 @@ module Element = struct
     | Unsolved of string
     | Solved of string * Type.t
     | Marker of string
-    [@@deriving eq]
+  [@@deriving eq]
 end
 
 type t = Element.t list
 
-type e =
-  | FailedToBreakApart
-  [@@deriving eq]
+type e = FailedToBreakApart [@@deriving eq]
 
 let rec apply (context : t) (t : Type.t) : Type.t =
   let open Type in
   match t with
-  | Constructor _ -> t
-  | Variable _ -> t
+  | Constructor _ ->
+      t
+  | Variable _ ->
+      t
   | Unsolved u ->
-     let find_solved = function
-       | Element.Solved (u', t) when String.equal u u' ->
-          if Type.is_mono_type t then
-            Some t
-          else
-            raise (Failure "A solved type in the context is not a monotype.")
-       | _ ->
-          None
-     in
-     let solved_type =
-       match List.find_map context ~f:find_solved with
-       | Some t -> apply context t
-       | None -> t
-     in
-     solved_type
+      let find_solved = function
+        | Element.Solved (u', t) when String.equal u u' ->
+            if Type.is_mono_type t then Some t
+            else
+              raise (Failure "A solved type in the context is not a monotype.")
+        | _ ->
+            None
+      in
+      let solved_type =
+        match List.find_map context ~f:find_solved with
+        | Some t ->
+            apply context t
+        | None ->
+            t
+      in
+      solved_type
   | Forall (a, k, t) ->
-     Forall (a, Option.map ~f:(apply context) k, apply context t)
+      Forall (a, Option.map ~f:(apply context) k, apply context t)
   | Apply (t1, t2) ->
-     Apply (apply context t1, apply context t2)
+      Apply (apply context t1, apply context t2)
   | KindApply (t1, t2) ->
-     KindApply (apply context t1, apply context t2)
+      KindApply (apply context t1, apply context t2)
   | Annotate (t1, t2) ->
-     Annotate (apply context t1, apply context t2)
+      Annotate (apply context t1, apply context t2)
 
 let mem (context : t) (element : Element.t) : bool =
   List.mem context element ~equal:Element.equal
 
 let discard_up_to (element : Element.t) (context : t) : t =
   let rec aux = function
-    | [] -> []
+    | [] ->
+        []
     | current :: rest ->
-       if Element.equal element current then
-         rest
-       else
-         aux rest
+        if Element.equal element current then rest else aux rest
   in
   aux context
 
 let break_apart_at (element : Element.t) (context : t) : (t * t, e) Result.t =
   let rec aux collected = function
-    | [] -> Error FailedToBreakApart
+    | [] ->
+        Error FailedToBreakApart
     | current :: rest ->
-       if Element.equal element current then
-         Ok (List.rev collected, rest)
-       else
-         aux (current :: collected) rest
+        if Element.equal element current then Ok (List.rev collected, rest)
+        else aux (current :: collected) rest
   in
   aux [] context

--- a/src/Context.mli
+++ b/src/Context.mli
@@ -1,0 +1,36 @@
+(** The type of context elements. *)
+module Element : sig
+  type t =
+    | Variable of string * Type.t
+    | Quantified of string * Type.t option
+    | Unsolved of string
+    | Solved of string * Type.t
+    | Marker of string
+
+  val equal : t -> t -> bool
+end
+
+(** The type of the context. *)
+type t = Element.t list
+
+(** The error type used in this module. *)
+module Error : sig
+  type t = FailedToBreakApart
+
+  val equal : t -> t -> bool
+end
+
+val apply : t -> Type.t -> Type.t
+(** [apply context _T] applies a context to a type _T. This takes all unsolved
+    variables and tries to solve them with respect to the provided context. *)
+
+val mem : t -> Element.t -> bool
+(** [mem context element] checks whether an element is a member of the context. *)
+
+val discard_up_to : Element.t -> t -> t
+(** [discard_up_to element context] discards all elements up to the provided
+    element in the provided context. *)
+
+val break_apart_at : Element.t -> t -> (t * t, Error.t) result
+(** [break_apart_at element context] breaks the context to its left and right
+    components relative to the provided element. *)

--- a/src/Expr.ml
+++ b/src/Expr.ml
@@ -1,5 +1,3 @@
-(** Expressions in the language. *)
-
 type 'a t =
   | Literal of 'a t Literal.t
   | Variable of string
@@ -9,8 +7,6 @@ type 'a t =
   | Let of string * Type.t option * 'a t * 'a t
 [@@deriving eq]
 
-(** [substitute a r e] takes all occurences of the variable a inside of an
-    expression e and replaces them with an expression r. *)
 let rec substitute (a : string) (r : _ t) (e : _ t) : _ t =
   match e with
   | Literal _ ->

--- a/src/Expr.ml
+++ b/src/Expr.ml
@@ -1,35 +1,31 @@
-(** Expressions in the language.  *)
+(** Expressions in the language. *)
 
 type 'a t =
-  | Literal of ('a t) Literal.t
+  | Literal of 'a t Literal.t
   | Variable of string
   | Lambda of string * 'a t
   | Apply of 'a t * 'a t
   | Annotate of 'a t * Type.t
   | Let of string * Type.t option * 'a t * 'a t
-  [@@deriving eq]
+[@@deriving eq]
 
 (** [substitute a r e] takes all occurences of the variable a inside of an
-    expression e and replaces them with an expression r.
-  *)
+    expression e and replaces them with an expression r. *)
 let rec substitute (a : string) (r : _ t) (e : _ t) : _ t =
   match e with
-  | Literal _ -> e
+  | Literal _ ->
+      e
   | Variable a' ->
-     if String.equal a a' then r else e
+      if String.equal a a' then r else e
   | Lambda (a', e') ->
-     if String.equal a a' then e else Lambda (a', substitute a r e')
+      if String.equal a a' then e else Lambda (a', substitute a r e')
   | Apply (f, x) ->
-     Apply (substitute a r f, substitute a r x)
+      Apply (substitute a r f, substitute a r x)
   | Annotate (e, t) ->
-     Annotate (substitute a r e, t)
+      Annotate (substitute a r e, t)
   | Let (a', n, e1, e2) ->
-     Let
-       ( a'
-       , n
-       , substitute a r e1
-       , if String.equal a a' then
-           e2
-         else
-           substitute a r e2
-       )
+      Let
+        ( a'
+        , n
+        , substitute a r e1
+        , if String.equal a a' then e2 else substitute a r e2 )

--- a/src/Expr.mli
+++ b/src/Expr.mli
@@ -1,0 +1,14 @@
+(** The type of expressions in the language. *)
+type 'a t =
+  | Literal of 'a t Literal.t
+  | Variable of string
+  | Lambda of string * 'a t
+  | Apply of 'a t * 'a t
+  | Annotate of 'a t * Type.t
+  | Let of string * Type.t option * 'a t * 'a t
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val substitute : string -> 'a t -> 'a t -> 'a t
+(** [substitute a r e] takes all occurences of the variable a inside of an
+    expression e and replaces them with an expression r. *)

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -27,9 +27,6 @@ let fresh_name : unit -> string =
     incr i ;
     "t" ^ string_of_int !i
 
-(** [well_formed_type context _T] determines the well-formedness of some type _T
-    with respect to the context. This function is used to partially verify the
-    correctness of the algorithmic context. *)
 let rec well_formed_type (context : Context.t) (_T : Type.t) :
     (unit, Error.t) result =
   match _T with
@@ -77,7 +74,6 @@ let scoped_unsolved context unsolved action =
 let annotate_type (_T : Type.t) (_K : Type.t option) =
   match _K with Some _K -> Annotate (_T, _K) | None -> _T
 
-(** [subtype _A _B] checks the subtyping relationship between _A and _B. *)
 let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
     (Context.t, Error.t) result =
   let open Primitives in
@@ -127,8 +123,6 @@ let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
   | _ ->
       Error (FailedSubtyping (_A, _B))
 
-(** [instantiateLeft a _A] instantiates the unsolved variable a with _B, such
-    that a is a subtype of _B. *)
 and instantiateLeft (gamma : Context.t) (a : string) (_B : Type.t) :
     (Context.t, Error.t) result =
   let open Primitives in
@@ -204,8 +198,6 @@ and instantiateLeft (gamma : Context.t) (a : string) (_B : Type.t) :
       let* theta = instantiateLeft gamma a' _A in
       instantiateLeft theta b' (Context.apply theta _B)
 
-(** [instantiateRight _A b] instantiates the unsolved variable b with _A, such
-    that _A is a subtype of b. *)
 and instantiateRight (gamma : Context.t) (_A : Type.t) (b : string) :
     (Context.t, Error.t) result =
   let open Primitives in
@@ -283,7 +275,6 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (b : string) :
       let* theta = instantiateRight gamma _A a' in
       instantiateRight theta (Context.apply theta _B) b'
 
-(** [check gamma e _A] checks that the expression e has the type _A. *)
 and check (gamma : Context.t) (e : _ Expr.t) (_A : Type.t) :
     (Context.t, Error.t) result =
   let open Primitives in
@@ -314,7 +305,6 @@ and check (gamma : Context.t) (e : _ Expr.t) (_A : Type.t) :
       let* theta, _A' = infer gamma e in
       subtype theta (Context.apply theta _A') (Context.apply theta _A)
 
-(** [infer gamma e] infers the type of an expression e. *)
 and infer (gamma : Context.t) (e : _ Expr.t) :
     (Context.t * Type.t, Error.t) result =
   let open Primitives in
@@ -382,8 +372,6 @@ and infer (gamma : Context.t) (e : _ Expr.t) :
       let v' = fresh_name () in
       infer (Variable (v', t) :: gamma) (Expr.substitute v (Variable v') e2)
 
-(** [infer_apply gamma _A e] infers the type of the application of some type _A
-    to an expression e. *)
 and infer_apply (gamma : Context.t) (_A : Type.t) (e : _ Expr.t) :
     (Context.t * Type.t, Error.t) result =
   let open Primitives in
@@ -417,7 +405,6 @@ and infer_apply (gamma : Context.t) (_A : Type.t) (e : _ Expr.t) :
   | _ ->
       Error (FailedInfererence (e, _A))
 
-(** [check_kind gamma _T _K] checks whether some type _T has a kind _K. *)
 and check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) :
     (Context.t, Error.t) result =
   let open Primitives in
@@ -448,7 +435,6 @@ and check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) :
       let* theta, _TK = infer_kind gamma _T in
       subtype theta (Context.apply theta _TK) (Context.apply theta _K)
 
-(** [infer_kind gamma _T] infers the kind of some type _T. *)
 and infer_kind (gamma : Context.t) (_T : Type.t) :
     (Context.t * Type.t, Error.t) result =
   let open Primitives in
@@ -501,8 +487,6 @@ and infer_kind (gamma : Context.t) (_T : Type.t) :
       | _ ->
           failwith "infer_kind: forall binder has no kind" )
 
-(** [infer_apply_kind gamma _K _X] infers the type of the application of the
-    kind _K to some type _X. *)
 and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
   let open Primitives in
   match _K with
@@ -535,8 +519,6 @@ and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
   | _ ->
       raise (Failure "Impossible case in synth_app_kind")
 
-(** [infer_type_with context e] infers the type of some expression e using the
-    provided context. *)
 let infer_type_with (context : Context.t) (e : _ Expr.t) :
     (Type.t, Error.t) result =
   let* delta, poly_type = infer context e in
@@ -556,5 +538,4 @@ let infer_type_with (context : Context.t) (e : _ Expr.t) :
   in
   Ok (List.fold_right delta ~f:algebra ~init:(Context.apply delta poly_type))
 
-(** [infer_type e] infers the type of some expression with an empty context. *)
 let infer_type : _ Expr.t -> (Type.t, Error.t) result = infer_type_with []

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -28,7 +28,12 @@ let rec well_formed_type (context : Context.t) (t : Type.t) : (unit, e) Result.t
   | Constructor _ ->
      Ok ()
   | Variable v ->
-     if Context.mem context (Quantified v) then
+     if Context.mem context (Quantified (v, None)) then
+       Ok ()
+     else
+       Error (IllFormedType t)
+  | Annotate (Variable v, k) ->
+     if Context.mem context (Quantified (v, Some k)) then
        Ok ()
      else
        Error (IllFormedType t)
@@ -44,7 +49,7 @@ let rec well_formed_type (context : Context.t) (t : Type.t) : (unit, e) Result.t
        | None -> Error (IllFormedType t)
      )
   | Forall (a, k, t) ->
-     let* () = well_formed_type (Quantified a :: context) t in
+     let* () = well_formed_type (Quantified (a, k) :: context) t in
      ( match k with
        | Some k -> well_formed_type context k
        | None -> Ok ()

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-
 open Context
 open Expr
 open Type
@@ -14,133 +13,125 @@ type e =
   | UnknownVariable of string
   | ContextError of Context.e
 
-let (let*) = Result.(>>=)
-let (and*) = Result.Let_syntax.Let_syntax.both
+let ( let* ) = Result.( >>= )
+
+let ( and* ) = Result.Let_syntax.Let_syntax.both
 
 (** [fresh_name ()] generates a unique name to avoid collisions. *)
 let fresh_name : unit -> string =
   let i = ref (-1) in
   fun () ->
-    incr i;
+    incr i ;
     "t" ^ string_of_int !i
 
 (** [well_formed_type context _T] determines the well-formedness of some type _T
     with respect to the context. This function is used to partially verify the
-    correctness of the algorithmic context.
- *)
-let rec well_formed_type (context : Context.t) (_T : Type.t) : (unit, e) Result.t =
+    correctness of the algorithmic context. *)
+let rec well_formed_type (context : Context.t) (_T : Type.t) :
+    (unit, e) Result.t =
   match _T with
   | Constructor _ ->
-     Ok ()
+      Ok ()
   | Variable v ->
-     if Context.mem context (Quantified (v, None)) then
-       Ok ()
-     else
-       Error (IllFormedType _T)
+      if Context.mem context (Quantified (v, None)) then Ok ()
+      else Error (IllFormedType _T)
   | Annotate (Variable v, k) ->
-     if Context.mem context (Quantified (v, Some k)) then
-       Ok ()
-     else
-       Error (IllFormedType _T)
-  | Unsolved u ->
-     let predicate : Element.t -> bool = function
-       | Unsolved u' | Solved (u', _) when String.equal u u' ->
-          true
-       | _ ->
-          false
-     in
-     ( match List.find context ~f:predicate with
-       | Some _ -> Ok ()
-       | None -> Error (IllFormedType _T)
-     )
-  | Forall (a, _K, _A) ->
-     let* () = well_formed_type (Quantified (a, _K) :: context) _A in
-     ( match _K with
-       | Some _K -> well_formed_type context _K
-       | None -> Ok ()
-     )
+      if Context.mem context (Quantified (v, Some k)) then Ok ()
+      else Error (IllFormedType _T)
+  | Unsolved u -> (
+      let predicate : Element.t -> bool = function
+        | (Unsolved u' | Solved (u', _)) when String.equal u u' ->
+            true
+        | _ ->
+            false
+      in
+      match List.find context ~f:predicate with
+      | Some _ ->
+          Ok ()
+      | None ->
+          Error (IllFormedType _T) )
+  | Forall (a, _K, _A) -> (
+      let* () = well_formed_type (Quantified (a, _K) :: context) _A in
+      match _K with Some _K -> well_formed_type context _K | None -> Ok () )
   | Apply (_A, _B) | KindApply (_A, _B) | Annotate (_A, _B) ->
-     let* _ = well_formed_type context _A
-     and* _ = well_formed_type context _B
-     in Ok ()
+      let* _ = well_formed_type context _A
+      and* _ = well_formed_type context _B in
+      Ok ()
 
 (** [scoped context element action] runs an algorithmic typing action inside by
-    first appending the element to the context, before popping the element.
- *)
+    first appending the element to the context, before popping the element. *)
 let scoped context element action =
   let* context' = action (element :: context) in
   Ok (Context.discard_up_to element context')
 
 (** [scoped_unsolved context unsolved action] is similar to scoped, except it
-    also appends a marker element along with the unsolved element.
- *)
+    also appends a marker element along with the unsolved element. *)
 let scoped_unsolved context unsolved action =
-  scoped context (Element.Marker unsolved)
-    (fun context -> action (Element.Unsolved unsolved :: context))
+  scoped context (Element.Marker unsolved) (fun context ->
+      action (Element.Unsolved unsolved :: context) )
 
 (** [annotate_type _T _K] optionally annotates some type _T with a kind _K. *)
 let annotate_type (_T : Type.t) (_K : Type.t option) =
-  match _K with
-  | Some _K ->
-     Annotate (_T, _K)
-  | None ->
-     _T
+  match _K with Some _K -> Annotate (_T, _K) | None -> _T
 
-let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) : (Context.t, e) result =
+let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
+    (Context.t, e) result =
   let open Primitives in
   match (_A, _B) with
   | Constructor a, Constructor b when String.equal a b ->
-     (* todo: perform environment checks here? *)
-     Ok gamma
+      (* todo: perform environment checks here? *)
+      Ok gamma
   | Variable a, Variable b when String.equal a b ->
-     (* `a` must exist within the context *)
-     let* _ = well_formed_type gamma _A in Ok gamma
+      (* `a` must exist within the context *)
+      let* _ = well_formed_type gamma _A in
+      Ok gamma
   (* we only need these variables to be unsolved *)
   | Unsolved a, Unsolved b
-       when String.equal a b && Context.mem gamma (Unsolved a) ->
-     Ok gamma
+    when String.equal a b && Context.mem gamma (Unsolved a) ->
+      Ok gamma
   (* function application is funky *)
-  | Apply (Apply (t_function1, a1), b1)
-  , Apply (Apply (t_function2, a2), b2)
-       when Type.equal t_function t_function1
-         && Type.equal t_function t_function2 ->
-     let* theta = subtype gamma a2 a1 in
-     subtype theta (Context.apply theta b1) (Context.apply theta b2)
+  | Apply (Apply (t_function1, a1), b1), Apply (Apply (t_function2, a2), b2)
+    when Type.equal t_function t_function1 && Type.equal t_function t_function2
+    ->
+      let* theta = subtype gamma a2 a1 in
+      subtype theta (Context.apply theta b1) (Context.apply theta b2)
   | _, Forall (b, _K, _B) ->
-     let b' = fresh_name () in
-     let _B = Type.substitute b (annotate_type (Variable b') _K) _B in
-     scoped gamma (Quantified (b', _K))
-       (fun gamma -> subtype gamma _A _B)
+      let b' = fresh_name () in
+      let _B = Type.substitute b (annotate_type (Variable b') _K) _B in
+      scoped gamma (Quantified (b', _K)) (fun gamma -> subtype gamma _A _B)
   | Forall (a, _K, _A), _ ->
-     let a' = fresh_name () in
-     let _A = Type.substitute a (annotate_type (Unsolved a') _K) _A in
-     scoped_unsolved gamma a'
-       (fun gamma -> subtype gamma _A _B)
+      let a' = fresh_name () in
+      let _A = Type.substitute a (annotate_type (Unsolved a') _K) _A in
+      scoped_unsolved gamma a' (fun gamma -> subtype gamma _A _B)
   | Unsolved a, _
-       when Context.mem gamma (Unsolved a)
+    when Context.mem gamma (Unsolved a)
          && not (Set.mem (Type.free_type_variables _B) a) ->
-     instantiateLeft gamma a _B
+      instantiateLeft gamma a _B
   | _, Unsolved b
-       when Context.mem gamma (Unsolved b)
-            && not (Set.mem (Type.free_type_variables _A) b) ->
-     instantiateRight gamma _A b
+    when Context.mem gamma (Unsolved b)
+         && not (Set.mem (Type.free_type_variables _A) b) ->
+      instantiateRight gamma _A b
   | Apply (a1, b1), Apply (a2, b2) ->
-     let* gamma = subtype gamma a1 a2 in subtype gamma b1 b2
+      let* gamma = subtype gamma a1 a2 in
+      subtype gamma b1 b2
   | _U, Annotate (_T, _K) ->
-     let* gamma = check_kind gamma _U _K in
-     subtype gamma _U _T
+      let* gamma = check_kind gamma _U _K in
+      subtype gamma _U _T
   | Annotate (_T, _K), _U ->
-     let* gamma = check_kind gamma _U _K in
-     subtype gamma _T _U
+      let* gamma = check_kind gamma _U _K in
+      subtype gamma _T _U
   | _ ->
-     Error (FailedSubtyping (_A, _B))
+      Error (FailedSubtyping (_A, _B))
 
-and instantiateLeft (gamma : Context.t) (a : string) (_A : Type.t) : (Context.t, e) result =
+and instantiateLeft (gamma : Context.t) (a : string) (_A : Type.t) :
+    (Context.t, e) result =
   let open Primitives in
-  let* (gammaL, gammaR) =
+  let* gammaL, gammaR =
     match break_apart_at (Unsolved a) gamma with
-    | Ok (gammaL, gammaR) -> Ok (gammaL, gammaR)
-    | Error e -> Error (ContextError e)
+    | Ok (gammaL, gammaR) ->
+        Ok (gammaL, gammaR)
+    | Error e ->
+        Error (ContextError e)
   in
   let solveLeft (t : Type.t) : (Context.t, e) result =
     let* _ = well_formed_type gammaR _A in
@@ -148,86 +139,74 @@ and instantiateLeft (gamma : Context.t) (a : string) (_A : Type.t) : (Context.t,
   in
   match _A with
   | Constructor _ ->
-     solveLeft _A
+      solveLeft _A
   | Variable _ ->
-     solveLeft _A
-  | Unsolved b ->
-     ( match break_apart_at (Unsolved b) gammaL with
-       | Error _ ->
-          solveLeft _A
-       | Ok (gammaLL, gammaLR) ->
-          let gammaL =
-            List.append gammaLL (Solved (b, Unsolved a) :: gammaLR)
-          in
-          let gamma =
-            List.append gammaL (Unsolved a :: gammaR)
-          in
-          Ok gamma
-     )
-  | Apply (Apply (t_function', _A), _B)
-       when Type.equal t_function t_function' ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateRight gamma _A a'
-     in
-     instantiateLeft theta b' (Context.apply theta _B)
+      solveLeft _A
+  | Unsolved b -> (
+    match break_apart_at (Unsolved b) gammaL with
+    | Error _ ->
+        solveLeft _A
+    | Ok (gammaLL, gammaLR) ->
+        let gammaL = List.append gammaLL (Solved (b, Unsolved a) :: gammaLR) in
+        let gamma = List.append gammaL (Unsolved a :: gammaR) in
+        Ok gamma )
+  | Apply (Apply (t_function', _A), _B) when Type.equal t_function t_function'
+    ->
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateRight gamma _A a' in
+      instantiateLeft theta b' (Context.apply theta _B)
   | Forall (b, _K, _B) ->
-     scoped gamma (Quantified (b, _K))
-       (fun gamma -> instantiateLeft gamma b _B)
+      scoped gamma (Quantified (b, _K)) (fun gamma -> instantiateLeft gamma b _B)
   | Apply (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Sugar.ap (Type.Unsolved a') (Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateLeft gamma a' _A
-     in
-     instantiateLeft theta b' (Context.apply theta _B)
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved (a, Sugar.ap (Type.Unsolved a') (Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateLeft gamma a' _A in
+      instantiateLeft theta b' (Context.apply theta _B)
   | KindApply (_, _) ->
-     (* KindApply isn't user-facing, so we shouldn't ever handle it when
-        performing instantiation.
-      *)
-     raise (Failure "instantiateLeft: called with KindApply")
+      (* KindApply isn't user-facing, so we shouldn't ever handle it when
+         performing instantiation. *)
+      raise (Failure "instantiateLeft: called with KindApply")
   | Annotate (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Type.Annotate (Type.Unsolved a', Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateLeft gamma a' _A
-     in
-     instantiateLeft theta b' (Context.apply theta _B)
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved
+              (a, Type.Annotate (Type.Unsolved a', Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateLeft gamma a' _A in
+      instantiateLeft theta b' (Context.apply theta _B)
 
-and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) : (Context.t, e) result =
+and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) :
+    (Context.t, e) result =
   let open Primitives in
-  let* (gammaL, gammaR) =
+  let* gammaL, gammaR =
     match break_apart_at (Unsolved a) gamma with
-    | Ok (gammaL, gammaR) -> Ok (gammaL, gammaR)
-    | Error e -> Error (ContextError e)
+    | Ok (gammaL, gammaR) ->
+        Ok (gammaL, gammaR)
+    | Error e ->
+        Error (ContextError e)
   in
   let solveRight (t : Type.t) : (Context.t, e) result =
     let* _ = well_formed_type gammaR _A in
@@ -235,328 +214,325 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) : (Context.t
   in
   match _A with
   | Constructor _ ->
-     solveRight _A
+      solveRight _A
   | Variable _ ->
-     solveRight _A
-  | Unsolved b ->
-     ( match break_apart_at (Unsolved b) gammaL with
-       | Error _ ->
-          solveRight _A
-       | Ok (gammaLL, gammaLR) ->
-          let gammaL =
-            List.append gammaLL (Solved (b, Unsolved a) :: gammaLR)
-          in
-          let gamma =
-            List.append gammaL (Unsolved a :: gammaR)
-          in
-          Ok gamma
-     )
-  | Apply (Apply (t_function', _A), _B)
-       when Type.equal t_function t_function' ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateLeft gamma a' _A
-     in
-     instantiateRight theta (Context.apply theta _B) b'
+      solveRight _A
+  | Unsolved b -> (
+    match break_apart_at (Unsolved b) gammaL with
+    | Error _ ->
+        solveRight _A
+    | Ok (gammaLL, gammaLR) ->
+        let gammaL = List.append gammaLL (Solved (b, Unsolved a) :: gammaLR) in
+        let gamma = List.append gammaL (Unsolved a :: gammaR) in
+        Ok gamma )
+  | Apply (Apply (t_function', _A), _B) when Type.equal t_function t_function'
+    ->
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateLeft gamma a' _A in
+      instantiateRight theta (Context.apply theta _B) b'
   | Forall (b, _K, _B) ->
-     let b' = fresh_name () in
-     let _B = Type.substitute b (annotate_type (Unsolved b') _K) _B in
-     scoped_unsolved gamma b'
-       (fun gamma -> instantiateRight gamma _B b')
+      let b' = fresh_name () in
+      let _B = Type.substitute b (annotate_type (Unsolved b') _K) _B in
+      scoped_unsolved gamma b' (fun gamma -> instantiateRight gamma _B b')
   | Apply (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Sugar.ap (Type.Unsolved a') (Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateRight gamma _A a'
-     in
-     instantiateRight theta (Context.apply theta _B) b'
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved (a, Sugar.ap (Type.Unsolved a') (Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateRight gamma _A a' in
+      instantiateRight theta (Context.apply theta _B) b'
   | KindApply (_, _) ->
-     (* KindApply isn't user-facing, so we shouldn't ever handle it when
-        performing instantiation.
-      *)
-     raise (Failure "instantiateRight: called with KindApply")
+      (* KindApply isn't user-facing, so we shouldn't ever handle it when
+         performing instantiation. *)
+      raise (Failure "instantiateRight: called with KindApply")
   | Annotate (_A, _B) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let gamma =
-       let gammaM =
-         [ Element.Solved (a, Type.Annotate (Type.Unsolved a', Type.Unsolved b'))
-         ; Element.Unsolved a'
-         ; Element.Unsolved b'
-         ]
-       in
-       List.concat [gammaL;gammaM;gammaR]
-     in
-     let* theta =
-       instantiateRight gamma _A a'
-     in
-     instantiateRight theta (Context.apply theta _B) b'
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let gamma =
+        let gammaM =
+          [ Element.Solved
+              (a, Type.Annotate (Type.Unsolved a', Type.Unsolved b'))
+          ; Element.Unsolved a'
+          ; Element.Unsolved b' ]
+        in
+        List.concat [gammaL; gammaM; gammaR]
+      in
+      let* theta = instantiateRight gamma _A a' in
+      instantiateRight theta (Context.apply theta _B) b'
 
-and check (gamma : Context.t) (e : _ Expr.t) (_A: Type.t) : (Context.t, e) result =
+and check (gamma : Context.t) (e : _ Expr.t) (_A : Type.t) :
+    (Context.t, e) result =
   let open Primitives in
   match (e, _A) with
-  | Literal l, (Constructor c) ->
-     ( match (l, c) with
-       | Char _, "Char"
-       | String _, "String"
-       | Int _, "Int"
-       | Float _, "Float" ->
-          Ok gamma
-       | Array _, "Array" ->
-          raise (Failure "todo: checking routine for arrays is not yet implemented")
-       | Object _, "Object" ->
-          raise (Failure "todo: checking routine for objects is not yet implemented")
-       | _ ->
-          Error (FailedChecking (e, _A))
-     )
+  | Literal l, Constructor c -> (
+    match (l, c) with
+    | Char _, "Char" | String _, "String" | Int _, "Int" | Float _, "Float" ->
+        Ok gamma
+    | Array _, "Array" ->
+        raise
+          (Failure "todo: checking routine for arrays is not yet implemented")
+    | Object _, "Object" ->
+        raise
+          (Failure "todo: checking routine for objects is not yet implemented")
+    | _ ->
+        Error (FailedChecking (e, _A)) )
   | Lambda (n, e), Apply (Apply (t_function', _A1), _A2)
-       when Type.equal t_function t_function' ->
-     let n' = fresh_name () in
-     scoped gamma (Variable (n', _A1))
-       (fun gamma -> check gamma (Expr.substitute n (Variable n') e)_A2)
+    when Type.equal t_function t_function' ->
+      let n' = fresh_name () in
+      scoped gamma
+        (Variable (n', _A1))
+        (fun gamma -> check gamma (Expr.substitute n (Variable n') e) _A2)
   | _, Forall (a, _K, _A) ->
-     let a' = fresh_name () in
-     let _A = Type.substitute a (annotate_type (Variable a') _K) _A in
-     scoped gamma (Quantified (a', _K))
-       (fun gamma -> check gamma e _A)
+      let a' = fresh_name () in
+      let _A = Type.substitute a (annotate_type (Variable a') _K) _A in
+      scoped gamma (Quantified (a', _K)) (fun gamma -> check gamma e _A)
   | _ ->
-     let* (theta, _A') = infer gamma e in
-     subtype theta (Context.apply theta _A') (Context.apply theta _A)
+      let* theta, _A' = infer gamma e in
+      subtype theta (Context.apply theta _A') (Context.apply theta _A)
 
 and infer (gamma : Context.t) (e : _ Expr.t) : (Context.t * Type.t, e) result =
   let open Primitives in
   match e with
   | Literal l ->
-     let t =
-     ( match l with
-       | Literal.Char _ -> t_char
-       | Literal.String _ -> t_string
-       | Literal.Int _ -> t_int
-       | Literal.Float _ -> t_float
-       | Literal.Array _ ->
-          raise (Failure "todo: inference routine for array is not yet implemented")
-       | Literal.Object (_, _) ->
-          raise (Failure "todo: inference routine for object is not yet implemented")
-     )
-     in Ok (gamma, t)
-  | Variable v ->
-     let find_variable = function
-       | Element.Variable (v', t) when String.equal v v' -> Some t
-       | _ -> None
-     in
-     ( match List.find_map gamma ~f:find_variable with
-       | Some t ->
+      let t =
+        match l with
+        | Literal.Char _ ->
+            t_char
+        | Literal.String _ ->
+            t_string
+        | Literal.Int _ ->
+            t_int
+        | Literal.Float _ ->
+            t_float
+        | Literal.Array _ ->
+            raise
+              (Failure
+                 "todo: inference routine for array is not yet implemented" )
+        | Literal.Object (_, _) ->
+            raise
+              (Failure
+                 "todo: inference routine for object is not yet implemented" )
+      in
+      Ok (gamma, t)
+  | Variable v -> (
+      let find_variable = function
+        | Element.Variable (v', t) when String.equal v v' ->
+            Some t
+        | _ ->
+            None
+      in
+      match List.find_map gamma ~f:find_variable with
+      | Some t ->
           Ok (gamma, t)
-       | None ->
-          Error (UnknownVariable v)
-     )
+      | None ->
+          Error (UnknownVariable v) )
   | Lambda (v, e) ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let* delta =
-       let v' = fresh_name () in
-       scoped (Unsolved b' :: Unsolved a' :: gamma) (Variable (v', Unsolved a'))
-         (fun gamma -> check gamma (Expr.substitute v (Variable v') e) (Unsolved b'))
-     in
-     Ok (delta, Sugar.fn (Unsolved a') (Unsolved b'))
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let* delta =
+        let v' = fresh_name () in
+        scoped
+          (Unsolved b' :: Unsolved a' :: gamma)
+          (Variable (v', Unsolved a'))
+          (fun gamma ->
+            check gamma (Expr.substitute v (Variable v') e) (Unsolved b') )
+      in
+      Ok (delta, Sugar.fn (Unsolved a') (Unsolved b'))
   | Apply (f, x) ->
-     let* (theta, t) = infer gamma f in
-     infer_apply theta (Context.apply theta t) x
+      let* theta, t = infer gamma f in
+      infer_apply theta (Context.apply theta t) x
   | Annotate (e, t) ->
-     let* theta = check gamma e t in Ok (theta, t)
+      let* theta = check gamma e t in
+      Ok (theta, t)
   | Let (v, t, e1, e2) ->
-     let* (gamma, t) =
-       match t with
-       | Some t ->
-          let* gamma = check gamma e1 t in Ok (gamma, t)
-       | None ->
-          infer gamma e1
-     in
-     let v' = fresh_name () in
-     infer
-       (Variable (v', t) :: gamma)
-       (Expr.substitute v (Variable v') e2)
+      let* gamma, t =
+        match t with
+        | Some t ->
+            let* gamma = check gamma e1 t in
+            Ok (gamma, t)
+        | None ->
+            infer gamma e1
+      in
+      let v' = fresh_name () in
+      infer (Variable (v', t) :: gamma) (Expr.substitute v (Variable v') e2)
 
-and infer_apply (gamma : Context.t) (_A : Type.t) (e : _ Expr.t) : (Context.t * Type.t, e) result =
+and infer_apply (gamma : Context.t) (_A : Type.t) (e : _ Expr.t) :
+    (Context.t * Type.t, e) result =
   let open Primitives in
   match _A with
   | Forall (a, _K, _A) ->
-     let a' = fresh_name () in
-     let _A = Type.substitute a (annotate_type (Unsolved a') _K) _A in
-     infer_apply (Unsolved a' :: gamma) _A e
+      let a' = fresh_name () in
+      let _A = Type.substitute a (annotate_type (Unsolved a') _K) _A in
+      infer_apply (Unsolved a' :: gamma) _A e
   | Unsolved a ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let* (gammaL, gammaR) =
-       match break_apart_at (Unsolved a') gamma with
-       | Ok (gammaL, gammaR) -> Ok (gammaL, gammaR)
-       | Error e -> Error (ContextError e)
-     in
-     let gammaM =
-       [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
-       ; Element.Unsolved a'
-       ; Element.Unsolved b'
-       ]
-     in
-     let gamma = List.concat [gammaL;gammaM;gammaR] in
-     let* delta = check gamma e (Unsolved a') in
-     Ok (delta, Unsolved b')
-  | Apply (Apply (t_function', _A), _B)
-       when Type.equal t_function t_function' ->
-     let* delta = check gamma e _A in
-     Ok (delta, _B)
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let* gammaL, gammaR =
+        match break_apart_at (Unsolved a') gamma with
+        | Ok (gammaL, gammaR) ->
+            Ok (gammaL, gammaR)
+        | Error e ->
+            Error (ContextError e)
+      in
+      let gammaM =
+        [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
+        ; Element.Unsolved a'
+        ; Element.Unsolved b' ]
+      in
+      let gamma = List.concat [gammaL; gammaM; gammaR] in
+      let* delta = check gamma e (Unsolved a') in
+      Ok (delta, Unsolved b')
+  | Apply (Apply (t_function', _A), _B) when Type.equal t_function t_function'
+    ->
+      let* delta = check gamma e _A in
+      Ok (delta, _B)
   | _ ->
-     Error (FailedInfererence (e, _A))
+      Error (FailedInfererence (e, _A))
 
-and check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) : (Context.t, e) result =
+and check_kind (gamma : Context.t) (_T : Type.t) (_K : Type.t) :
+    (Context.t, e) result =
   let open Primitives in
   match (_T, _K) with
-  | Constructor _, Constructor "Type"
-       when is_primitive_type _T ->
-     Ok gamma
-  | Constructor _, Apply (Apply (t_function', Constructor "Type"), Constructor "Type")
-       when Type.equal t_function t_function'
-         && is_primitive_type_type _T ->
-     Ok gamma
-  | Constructor "Function"
-  , Apply
-      ( Apply
-          ( Constructor "Function"
-          , Constructor "Type"
-          )
-      , Apply
-          ( Apply
-              ( Constructor "Function"
-              , Constructor "Type"
-              )
-          , Constructor "Type"
-          )
-      ) ->
-     Ok gamma
+  | Constructor _, Constructor "Type" when is_primitive_type _T ->
+      Ok gamma
+  | ( Constructor _
+    , Apply (Apply (t_function', Constructor "Type"), Constructor "Type") )
+    when Type.equal t_function t_function' && is_primitive_type_type _T ->
+      Ok gamma
+  | ( Constructor "Function"
+    , Apply
+        ( Apply (Constructor "Function", Constructor "Type")
+        , Apply
+            ( Apply (Constructor "Function", Constructor "Type")
+            , Constructor "Type" ) ) ) ->
+      Ok gamma
   | Constructor _, _ ->
-     raise (Failure "todo: arbitrary constructors should look up the environment")
+      raise
+        (Failure "todo: arbitrary constructors should look up the environment")
   | _, Forall (a, _K', _A) ->
-     let a' = fresh_name () in
-     let _A = Type.substitute a (annotate_type (Variable a') _K') _A in
-     scoped gamma (Quantified (a', _K'))
-       (function gamma -> check_kind gamma _T _A)
+      let a' = fresh_name () in
+      let _A = Type.substitute a (annotate_type (Variable a') _K') _A in
+      scoped gamma
+        (Quantified (a', _K'))
+        (function gamma -> check_kind gamma _T _A)
   | _ ->
-     let* (theta, _TK) = infer_kind gamma _T in
-     subtype theta (Context.apply theta _TK) (Context.apply theta _K)
+      let* theta, _TK = infer_kind gamma _T in
+      subtype theta (Context.apply theta _TK) (Context.apply theta _K)
 
-and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) result =
+and infer_kind (gamma : Context.t) (_T : Type.t) :
+    (Context.t * Type.t, e) result =
   let open Primitives in
   match _T with
   | Constructor _ when is_primitive_type _T ->
-     Ok (gamma, t_type)
+      Ok (gamma, t_type)
   | Constructor _ when is_primitive_type_type _T ->
-     Ok (gamma, Sugar.fn t_type t_type)
+      Ok (gamma, Sugar.fn t_type t_type)
   | Constructor "Function" ->
-     Ok (gamma, Sugar.fn t_type (Sugar.fn t_type t_type))
+      Ok (gamma, Sugar.fn t_type (Sugar.fn t_type t_type))
   | Constructor _ ->
-     raise (Failure "Kind synthesis failed for arbitrary constructors.")
-  | Apply (Apply (t_function', _A), _B)
-       when Type.equal t_function t_function' ->
-     let* gamma = check_kind gamma _A t_type in
-     let* gamma = check_kind gamma _B t_type in
-     Ok (gamma, t_type)
+      raise (Failure "Kind synthesis failed for arbitrary constructors.")
+  | Apply (Apply (t_function', _A), _B) when Type.equal t_function t_function'
+    ->
+      let* gamma = check_kind gamma _A t_type in
+      let* gamma = check_kind gamma _B t_type in
+      Ok (gamma, t_type)
   | Forall (a, _K', _A) ->
-     let a' = fresh_name () in
-     let _A = Type.substitute a (annotate_type (Unsolved a') _K') _A in
-     let* (gamma, _K) = infer_kind (Unsolved a' :: gamma) _A
-     in Ok (Context.discard_up_to (Unsolved a') gamma, _K)
+      let a' = fresh_name () in
+      let _A = Type.substitute a (annotate_type (Unsolved a') _K') _A in
+      let* gamma, _K = infer_kind (Unsolved a' :: gamma) _A in
+      Ok (Context.discard_up_to (Unsolved a') gamma, _K)
   | Unsolved u ->
-     let u' = fresh_name () in
-     Ok (Unsolved u' :: gamma, (Type.substitute u (Unsolved u') _T))
-  | Variable v ->
-     let find_variable : Element.t -> Type.t option = function
-       | Variable (v', t) when String.equal v v' -> Some t
-       | _ -> None
-     in
-     ( match List.find_map gamma ~f:find_variable with
-       | Some t ->
+      let u' = fresh_name () in
+      Ok (Unsolved u' :: gamma, Type.substitute u (Unsolved u') _T)
+  | Variable v -> (
+      let find_variable : Element.t -> Type.t option = function
+        | Variable (v', t) when String.equal v v' ->
+            Some t
+        | _ ->
+            None
+      in
+      match List.find_map gamma ~f:find_variable with
+      | Some t ->
           Ok (gamma, t)
-       | None ->
-          Error (UnknownVariable v)
-     )
+      | None ->
+          Error (UnknownVariable v) )
   | Apply (_A, _B) ->
-     let* (gamma, _K) = infer_kind gamma _A in
-     infer_apply_kind gamma _K _B
+      let* gamma, _K = infer_kind gamma _A in
+      infer_apply_kind gamma _K _B
   | Annotate (_A, _B) ->
-     let* gamma = check_kind gamma _A _B in Ok (gamma, _B)
-  | KindApply (_A, _B) ->
-     let* (gamma, _A_K) = infer_kind gamma _A in
-     match _A_K with
-     | Forall (a, Some k, t) ->
-        let* gamma = check_kind gamma _B k in
-        Ok (gamma, Type.substitute a _B t)
-     | _ ->
-        failwith "infer_kind: forall binder has no kind"
+      let* gamma = check_kind gamma _A _B in
+      Ok (gamma, _B)
+  | KindApply (_A, _B) -> (
+      let* gamma, _A_K = infer_kind gamma _A in
+      match _A_K with
+      | Forall (a, Some k, t) ->
+          let* gamma = check_kind gamma _B k in
+          Ok (gamma, Type.substitute a _B t)
+      | _ ->
+          failwith "infer_kind: forall binder has no kind" )
 
 and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
   let open Primitives in
   match _K with
   | Forall (a, _K', _K) ->
-     let a' = fresh_name () in
-     let _K = Type.substitute a (annotate_type (Unsolved a') _K') _K in
-     infer_apply_kind (Unsolved a' :: gamma) _K _X
+      let a' = fresh_name () in
+      let _K = Type.substitute a (annotate_type (Unsolved a') _K') _K in
+      infer_apply_kind (Unsolved a' :: gamma) _K _X
   | Unsolved a ->
-     let a' = fresh_name () in
-     let b' = fresh_name () in
-     let* (gammaL, gammaR) =
-       match break_apart_at (Unsolved a) gamma with
-       | Ok (gammaL, gammaR) -> Ok (gammaL, gammaR)
-       | Error e -> Error (ContextError e)
-     in
-     let gammaM =
-       [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
-       ; Element.Unsolved a'
-       ; Element.Unsolved b'
-       ]
-     in
-     let gamma = List.concat [gammaL;gammaM;gammaR] in
-     let* delta = check_kind gamma _X (Unsolved a') in
-     Ok (delta, Unsolved b')
-  | Apply (Apply (t_function', _A), _B)
-       when Type.equal t_function t_function' ->
-     let* delta = check_kind gamma _X _A in Ok (delta, _B)
+      let a' = fresh_name () in
+      let b' = fresh_name () in
+      let* gammaL, gammaR =
+        match break_apart_at (Unsolved a) gamma with
+        | Ok (gammaL, gammaR) ->
+            Ok (gammaL, gammaR)
+        | Error e ->
+            Error (ContextError e)
+      in
+      let gammaM =
+        [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
+        ; Element.Unsolved a'
+        ; Element.Unsolved b' ]
+      in
+      let gamma = List.concat [gammaL; gammaM; gammaR] in
+      let* delta = check_kind gamma _X (Unsolved a') in
+      Ok (delta, Unsolved b')
+  | Apply (Apply (t_function', _A), _B) when Type.equal t_function t_function'
+    ->
+      let* delta = check_kind gamma _X _A in
+      Ok (delta, _B)
   | _ ->
-     raise (Failure "Impossible case in synth_app_kind")
+      raise (Failure "Impossible case in synth_app_kind")
 
 let infer_type_with (context : Context.t) (e : _ Expr.t) : (Type.t, e) result =
-  let* (delta, poly_type) = infer context e in
+  let* delta, poly_type = infer context e in
   let fresh_variable =
     let i = ref (-1) in
     fun () ->
-      incr i;
+      incr i ;
       String.of_char (Char.of_int_exn (97 + (!i mod 26)))
   in
   let algebra element poly_type =
     match element with
     | Element.Unsolved u ->
-       let u' = fresh_variable () in
-       Forall (u', None, Type.substitute u (Variable u') poly_type)
+        let u' = fresh_variable () in
+        Forall (u', None, Type.substitute u (Variable u') poly_type)
     | _ ->
-       poly_type
+        poly_type
   in
   Ok (List.fold_right delta ~f:algebra ~init:(Context.apply delta poly_type))
 

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -16,9 +16,9 @@ module Error = struct
   [@@deriving eq]
 end
 
-let ( let* ) = Result.( >>= )
+let ( let* ) : (_, Error.t) result -> _ = Result.( >>= )
 
-let ( and* ) = Result.Let_syntax.Let_syntax.both
+let ( and* ) : (_, Error.t) result -> _ = Result.Let_syntax.Let_syntax.both
 
 (** [fresh_name ()] generates a unique name to avoid collisions. *)
 let fresh_name : unit -> string =
@@ -134,7 +134,7 @@ and instantiateLeft (gamma : Context.t) (a : string) (_A : Type.t) :
     | Ok (gammaL, gammaR) ->
         Ok (gammaL, gammaR)
     | Error e ->
-        Error (Error.ContextError e)
+        Error (ContextError e)
   in
   let solveLeft (t : Type.t) : (Context.t, Error.t) result =
     let* _ = well_formed_type gammaR _A in
@@ -209,7 +209,7 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) :
     | Ok (gammaL, gammaR) ->
         Ok (gammaL, gammaR)
     | Error e ->
-        Error (Error.ContextError e)
+        Error (ContextError e)
   in
   let solveRight (t : Type.t) : (Context.t, Error.t) result =
     let* _ = well_formed_type gammaR _A in
@@ -391,7 +391,7 @@ and infer_apply (gamma : Context.t) (_A : Type.t) (e : _ Expr.t) :
         | Ok (gammaL, gammaR) ->
             Ok (gammaL, gammaR)
         | Error e ->
-            Error (Error.ContextError e)
+            Error (ContextError e)
       in
       let gammaM =
         [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))
@@ -505,7 +505,7 @@ and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
         | Ok (gammaL, gammaR) ->
             Ok (gammaL, gammaR)
         | Error e ->
-            Error (Error.ContextError e)
+            Error (ContextError e)
       in
       let gammaM =
         [ Element.Solved (a, Sugar.fn (Type.Unsolved a') (Type.Unsolved b'))

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -20,7 +20,7 @@ let (and*) = Result.Let_syntax.Let_syntax.both
 (** [fresh_name ()] generates a unique name to avoid collisions. *)
 let fresh_name : unit -> string =
   let i = ref (-1) in
-  function () ->
+  fun () ->
     incr i;
     "t" ^ string_of_int !i
 
@@ -76,7 +76,7 @@ let scoped context element action =
  *)
 let scoped_unsolved context unsolved action =
   scoped context (Element.Marker unsolved)
-    (function context -> action (Element.Unsolved unsolved :: context))
+    (fun context -> action (Element.Unsolved unsolved :: context))
 
 (** [annotate_type _T _K] optionally annotates some type _T with a kind _K. *)
 let annotate_type (_T : Type.t) (_K : Type.t option) =
@@ -332,12 +332,12 @@ and check (gamma : Context.t) (e : _ Expr.t) (_A: Type.t) : (Context.t, e) resul
        when Type.equal t_function t_function' ->
      let n' = fresh_name () in
      scoped gamma (Variable (n', _A1))
-       (function gamma -> check gamma (Expr.substitute n (Variable n') e)_A2)
+       (fun gamma -> check gamma (Expr.substitute n (Variable n') e)_A2)
   | _, Forall (a, _K, _A) ->
      let a' = fresh_name () in
      let _A = Type.substitute a (annotate_type (Variable a') _K) _A in
      scoped gamma (Quantified (a', _K))
-       (function gamma -> check gamma e _A)
+       (fun gamma -> check gamma e _A)
   | _ ->
      let* (theta, _A') = infer gamma e in
      subtype theta (Context.apply theta _A') (Context.apply theta _A)
@@ -375,7 +375,7 @@ and infer (gamma : Context.t) (e : _ Expr.t) : (Context.t * Type.t, e) result =
      let* delta =
        let v' = fresh_name () in
        scoped (Unsolved b' :: Unsolved a' :: gamma) (Variable (v', Unsolved a'))
-         (function gamma -> check gamma (Expr.substitute v (Variable v') e) (Unsolved b'))
+         (fun gamma -> check gamma (Expr.substitute v (Variable v') e) (Unsolved b'))
      in
      Ok (delta, Sugar.fn (Unsolved a') (Unsolved b'))
   | Apply (f, x) ->
@@ -546,7 +546,7 @@ let infer_type_with (context : Context.t) (e : _ Expr.t) : (Type.t, e) result =
   let* (delta, poly_type) = infer context e in
   let fresh_variable =
     let i = ref (-1) in
-    function () ->
+    fun () ->
       incr i;
       String.of_char (Char.of_int_exn (97 + (!i mod 26)))
   in

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -208,19 +208,19 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) : (Context.t
     | Ok (gammaL, gammaR) -> Ok (gammaL, gammaR)
     | Error e -> Error (ContextError e)
   in
-  let solveLeft (t : Type.t) : (Context.t, e) result =
+  let solveRight (t : Type.t) : (Context.t, e) result =
     let* _ = well_formed_type gammaR _A in
     Ok (List.append gammaL (Solved (a, t) :: gammaR))
   in
   match _A with
   | Constructor _ ->
-     solveLeft _A
+     solveRight _A
   | Variable _ ->
-     solveLeft _A
+     solveRight _A
   | Unsolved b ->
      ( match break_apart_at (Unsolved b) gammaL with
        | Error _ ->
-          solveLeft _A
+          solveRight _A
        | Ok (gammaLL, gammaLR) ->
           let gammaL =
             List.append gammaLL (Solved (b, Unsolved a) :: gammaLR)
@@ -250,7 +250,7 @@ and instantiateRight (gamma : Context.t) (_A : Type.t) (a : string) : (Context.t
   | Forall (b, _, _B) ->
      let b' = fresh_name () in
      scoped_unsolved gamma b'
-       (function gamma -> instantiateLeft gamma b' (Type.substitute b (Unsolved b') _B))
+       (function gamma -> instantiateRight gamma (Type.substitute b (Unsolved b') _B) b')
   | Apply (_A, _B) ->
      let a' = fresh_name () in
      let b' = fresh_name () in

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -25,7 +25,8 @@ let fresh_name : unit -> string =
     "t" ^ string_of_int !i
 
 (** [well_formed_type context _T] determines the well-formedness of some type _T
-    given the provided context.
+    with respect to the context. This function is used to partially verify the
+    correctness of the algorithmic context.
  *)
 let rec well_formed_type (context : Context.t) (_T : Type.t) : (unit, e) Result.t =
   match _T with
@@ -52,15 +53,15 @@ let rec well_formed_type (context : Context.t) (_T : Type.t) : (unit, e) Result.
        | Some _ -> Ok ()
        | None -> Error (IllFormedType _T)
      )
-  | Forall (a, _K, _T) ->
-     let* () = well_formed_type (Quantified (a, _K) :: context) _T in
+  | Forall (a, _K, _A) ->
+     let* () = well_formed_type (Quantified (a, _K) :: context) _A in
      ( match _K with
        | Some _K -> well_formed_type context _K
        | None -> Ok ()
      )
-  | Apply (t1, t2) | KindApply (t1, t2) | Annotate (t1, t2) ->
-     let* _ = well_formed_type context t1
-     and* _ = well_formed_type context t2
+  | Apply (_A, _B) | KindApply (_A, _B) | Annotate (_A, _B) ->
+     let* _ = well_formed_type context _A
+     and* _ = well_formed_type context _B
      in Ok ()
 
 (** [scoped context element action] runs an algorithmic typing action inside by

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -48,10 +48,10 @@ let rec well_formed_type (context : Context.t) (t : Type.t) : (unit, e) Result.t
        | Some _ -> Ok ()
        | None -> Error (IllFormedType t)
      )
-  | Forall (a, k, t) ->
-     let* () = well_formed_type (Quantified (a, k) :: context) t in
-     ( match k with
-       | Some k -> well_formed_type context k
+  | Forall (a, _K, _T) ->
+     let* () = well_formed_type (Quantified (a, _K) :: context) _T in
+     ( match _K with
+       | Some _K -> well_formed_type context _K
        | None -> Ok ()
      )
   | Apply (t1, t2) | KindApply (t1, t2) | Annotate (t1, t2) ->

--- a/src/Infer.ml
+++ b/src/Infer.ml
@@ -62,11 +62,6 @@ let scoped_unsolved context unsolved action =
   scoped context (Element.Marker unsolved)
     (function context -> action (Element.Unsolved unsolved :: context))
 
-let maybe_annotate (_T : Type.t) =
-  function
-  | Some k -> Annotate (_T, k)
-  | None -> _T
-
 let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) : (Context.t, e) result =
   let open Primitives in
   match (_A, _B) with
@@ -87,14 +82,14 @@ let rec subtype (gamma : Context.t) (_A : Type.t) (_B : Type.t) : (Context.t, e)
          && Type.equal t_function t_function2 ->
      let* theta = subtype gamma a2 a1 in
      subtype theta (Context.apply theta b1) (Context.apply theta b2)
-  | _, Forall (b, k, _B) ->
+  | _, Forall (b, _, _B) ->
      let b' = fresh_name () in
-     scoped_unsolved gamma b'
-       (function gamma -> subtype gamma _A (Type.substitute b (maybe_annotate (Unsolved b') k) _B))
-  | Forall (a, k, _A), _ ->
+     scoped gamma (Quantified b')
+       (function gamma -> subtype gamma _A (Type.substitute b (Variable b') _B))
+  | Forall (a, _, _A), _ ->
      let a' = fresh_name () in
      scoped_unsolved gamma a'
-       (function gamma -> subtype gamma (Type.substitute a (maybe_annotate (Unsolved a') k) _A) _B)
+       (function gamma -> subtype gamma (Type.substitute a (Unsolved a') _A) _B)
   | Unsolved a, _
        when Context.mem gamma (Unsolved a)
          && not (Set.mem (Type.free_type_variables _B) a) ->
@@ -454,9 +449,9 @@ and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) resul
      let* gamma = check_kind gamma _A t_type in
      let* gamma = check_kind gamma _B t_type in
      Ok (gamma, t_type)
-  | Forall (a, k, _A) ->
+  | Forall (a, _, _A) ->
      let a' = fresh_name () in
-     let* (gamma, _K) = infer_kind (Unsolved a' :: gamma) (Type.substitute a (maybe_annotate (Unsolved a') k) _A)
+     let* (gamma, _K) = infer_kind (Unsolved a' :: gamma) (Type.substitute a (Unsolved a') _A)
      in Ok (Context.discard_up_to (Unsolved a') gamma, _K)
   | Unsolved u ->
      let u' = fresh_name () in
@@ -489,9 +484,9 @@ and infer_kind (gamma : Context.t) (_T : Type.t) : (Context.t * Type.t, e) resul
 and infer_apply_kind (gamma : Context.t) (_K : Type.t) (_X : Type.t) =
   let open Primitives in
   match _K with
-  | Forall (a, k, _K) ->
+  | Forall (a, _, _K) ->
      let a' = fresh_name () in
-     infer_apply_kind (Unsolved a' :: gamma) (Type.substitute a (maybe_annotate (Unsolved a') k) _K) _X
+     infer_apply_kind (Unsolved a' :: gamma) (Type.substitute a (Unsolved a') _K) _X
   | Unsolved a ->
      let a' = fresh_name () in
      let b' = fresh_name () in

--- a/src/Infer.mli
+++ b/src/Infer.mli
@@ -1,0 +1,61 @@
+(** The error type used in this module. *)
+module Error : sig
+  type t =
+    | FailedSubtyping of Type.t * Type.t
+    | FailedChecking of unit Expr.t * Type.t
+    | FailedInfererence of unit Expr.t * Type.t
+    | FailedInstantiation of string * Type.t
+    | FailedKindChecking of Type.t * Type.t
+    | IllFormedType of Type.t
+    | UnknownVariable of string
+    | ContextError of Context.Error.t
+
+  val equal : t -> t -> bool
+end
+
+val well_formed_type : Context.t -> Type.t -> (unit, Error.t) result
+(** [well_formed_type context _T] determines the well-formedness of some type _T
+    with respect to the context. This function is used to partially verify the
+    correctness of the algorithmic context. *)
+
+val subtype : Context.t -> Type.t -> Type.t -> (Context.t, Error.t) result
+(** [subtype _A _B] checks the subtyping relationship between _A and _B. *)
+
+val instantiateLeft :
+  Context.t -> string -> Type.t -> (Context.t, Error.t) result
+(** [instantiateLeft a _A] instantiates the unsolved variable a with _B, such
+    that a is a subtype of _B. *)
+
+val instantiateRight :
+  Context.t -> Type.t -> string -> (Context.t, Error.t) result
+(** [instantiateRight _A b] instantiates the unsolved variable b with _A, such
+    that _A is a subtype of b. *)
+
+val check : Context.t -> unit Expr.t -> Type.t -> (Context.t, Error.t) result
+(** [check gamma e _A] checks that the expression e has the type _A. *)
+
+val infer : Context.t -> unit Expr.t -> (Context.t * Type.t, Error.t) result
+(** [infer gamma e] infers the type of an expression e. *)
+
+val infer_apply :
+  Context.t -> Type.t -> unit Expr.t -> (Context.t * Type.t, Error.t) result
+(** [infer_apply gamma _A e] infers the type of the application of some type _A
+    to an expression e. *)
+
+val check_kind : Context.t -> Type.t -> Type.t -> (Context.t, Error.t) result
+(** [check_kind gamma _T _K] checks whether some type _T has a kind _K. *)
+
+val infer_kind : Context.t -> Type.t -> (Context.t * Type.t, Error.t) result
+(** [infer_kind gamma _T] infers the kind of some type _T. *)
+
+val infer_apply_kind :
+  Context.t -> Type.t -> Type.t -> (Context.t * Type.t, Error.t) result
+(** [infer_apply_kind gamma _K _X] infers the type of the application of the
+    kind _K to some type _X. *)
+
+val infer_type_with : Context.t -> unit Expr.t -> (Type.t, Error.t) result
+(** [infer_type_with context e] infers the type of some expression e using the
+    provided context. *)
+
+val infer_type : unit Expr.t -> (Type.t, Error.t) result
+(** [infer_type e] infers the type of some expression with an empty context. *)

--- a/src/Literal.ml
+++ b/src/Literal.ml
@@ -1,4 +1,4 @@
-(** Literals in the language.  *)
+(** Literals in the language. *)
 
 type 'a t =
   | Char of char
@@ -7,4 +7,4 @@ type 'a t =
   | Float of float
   | Array of 'a list
   | Object of string * 'a list
-  [@@deriving eq]
+[@@deriving eq]

--- a/src/Log.ml
+++ b/src/Log.ml
@@ -1,6 +1,3 @@
 include Dolog.Log
 
-let () =
-  set_log_level DEBUG;
-  set_output stderr;
-  color_on ();
+let () = set_log_level DEBUG ; set_output stderr ; color_on ()

--- a/src/Type.ml
+++ b/src/Type.ml
@@ -11,53 +11,40 @@ type t =
   | Apply of t * t
   | KindApply of t * t
   | Annotate of t * t
-  [@@deriving eq]
+[@@deriving eq]
 
 (** [substitute a r t] takes all occurences of the variable a inside of a type t
     and replaces them with the type r. This is essentially just alpha conversion
-    for types.
-  *)
+    for types. *)
 let rec substitute (a : string) (r : t) (t : t) : t =
   match t with
-  | Constructor _ -> t
+  | Constructor _ ->
+      t
   | Variable a' | Unsolved a' ->
-     if String.equal a a' then r else t
+      if String.equal a a' then r else t
   | Forall (a', k, t) ->
-     if String.equal a a' then t else Forall (a', k, substitute a r t)
+      if String.equal a a' then t else Forall (a', k, substitute a r t)
   | Apply (t1, t2) ->
-     Apply
-       ( substitute a r t1
-       , substitute a r t2
-       )
+      Apply (substitute a r t1, substitute a r t2)
   | KindApply (t1, t2) ->
-     KindApply
-       ( substitute a r t1
-       , substitute a r t2
-       )
+      KindApply (substitute a r t1, substitute a r t2)
   | Annotate (t1, t2) ->
-     Annotate
-       ( substitute a r t1
-       , substitute a r t2
-       )
+      Annotate (substitute a r t1, substitute a r t2)
 
 (** [is_mono_type t] determines whether some type t is a monotype. *)
-let is_mono_type (t : t) : bool =
-  match t with
-  | Forall _ -> false
-  | _ -> true
+let is_mono_type (t : t) : bool = match t with Forall _ -> false | _ -> true
 
-(** [free_type_variables t] determines the free type variables in some type t.
-  *)
+(** [free_type_variables t] determines the free type variables in some type t. *)
 let rec free_type_variables (t : t) : type_vars_t =
   match t with
   | Constructor _ ->
-     Set.empty (module String)
+      Set.empty (module String)
   | Variable v | Unsolved v ->
-     Set.singleton (module String) v
+      Set.singleton (module String) v
   | Forall (a, _, t) ->
-     Set.remove (free_type_variables t) a
+      Set.remove (free_type_variables t) a
   | Apply (t1, t2) | KindApply (t1, t2) | Annotate (t1, t2) ->
-     Set.union (free_type_variables t1) (free_type_variables t2)
+      Set.union (free_type_variables t1) (free_type_variables t2)
 
 module Primitives = struct
   let t_type = Constructor "Type"
@@ -75,10 +62,9 @@ module Primitives = struct
   let t_function = Constructor "Function"
 
   let is_primitive_type n =
-    List.mem [t_type;t_char;t_string;t_int;t_float] n ~equal:equal
+    List.mem [t_type; t_char; t_string; t_int; t_float] n ~equal
 
-  let is_primitive_type_type n =
-    List.mem [t_array] n ~equal:equal
+  let is_primitive_type_type n = List.mem [t_array] n ~equal
 end
 
 module Sugar = struct

--- a/src/Type.ml
+++ b/src/Type.ml
@@ -13,9 +13,6 @@ type t =
   | Annotate of t * t
 [@@deriving eq]
 
-(** [substitute a r t] takes all occurences of the variable a inside of a type t
-    and replaces them with the type r. This is essentially just alpha conversion
-    for types. *)
 let rec substitute (a : string) (r : t) (t : t) : t =
   match t with
   | Constructor _ ->
@@ -31,10 +28,8 @@ let rec substitute (a : string) (r : t) (t : t) : t =
   | Annotate (t1, t2) ->
       Annotate (substitute a r t1, substitute a r t2)
 
-(** [is_mono_type t] determines whether some type t is a monotype. *)
 let is_mono_type (t : t) : bool = match t with Forall _ -> false | _ -> true
 
-(** [free_type_variables t] determines the free type variables in some type t. *)
 let rec free_type_variables (t : t) : type_vars_t =
   match t with
   | Constructor _ ->

--- a/src/Type.mli
+++ b/src/Type.mli
@@ -1,0 +1,54 @@
+type type_vars_t = Core_kernel.Set.M(Core_kernel.String).t
+
+(** The type of types in the language. *)
+type t =
+  | Constructor of string
+  | Variable of string
+  | Unsolved of string
+  | Forall of string * t option * t
+  | Apply of t * t
+  | KindApply of t * t
+  | Annotate of t * t
+
+val equal : t -> t -> bool
+
+val substitute : string -> t -> t -> t
+(** [substitute a r t] takes all occurences of the variable a inside of a type t
+    and replaces them with the type r. This is essentially just alpha conversion
+    for types. *)
+
+val is_mono_type : t -> bool
+(** [is_mono_type t] determines whether some type t is a monotype. *)
+
+val free_type_variables : t -> type_vars_t
+(** [free_type_variables t] determines the free type variables in some type t. *)
+
+(** Primitive types in the language. *)
+module Primitives : sig
+  val t_type : t
+
+  val t_char : t
+
+  val t_string : t
+
+  val t_int : t
+
+  val t_float : t
+
+  val t_array : t
+
+  val t_function : t
+
+  val is_primitive_type : t -> bool
+
+  val is_primitive_type_type : t -> bool
+end
+
+(** Syntax sugar for writing types. *)
+module Sugar : sig
+  val fn : t -> t -> t
+  (** Smart constructor for creating functions. *)
+
+  val ap : t -> t -> t
+  (** Smart constructor for creating applications. *)
+end

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,5 @@
  (name sulfur)
  (public_name sulfur)
  (libraries core_kernel dolog)
- (preprocess (pps ppx_deriving.eq)))
+ (preprocess
+  (pps ppx_deriving.eq)))


### PR DESCRIPTION
Closes #4. This makes bidirectional typing rules aware of kinds. This also adds an ocamlformat configuration as well as interface files for the modules.