### PR TITLE
Mark alcotest as a test dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
-      - run: opam install "alcotest>=1.5.0"
-
       - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,8 @@
  (name "sulfur_core")
  (synopsis "Core modules for the language")
  (depends
+  ("alcotest"
+   (and :with-test (>= "1.5.0")))
   ("core_kernel"
    (>= "v0.14.2"))
   ("ppx_deriving"

--- a/sulfur_core.opam
+++ b/sulfur_core.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/sjpgarcia/sulfur"
 bug-reports: "https://github.com/sjpgarcia/sulfur/issues"
 depends: [
   "dune" {>= "2.9"}
+  "alcotest" {with-test & >= "1.5.0"}
   "core_kernel" {>= "v0.14.2"}
   "ppx_deriving" {>= "5.2.1"}
   "dolog" {>= "6.0.0"}


### PR DESCRIPTION
This makes use of dune's opam integration to mark alcotest as a test dependency.
