### PR TITLE
Fold subtyping into unification

### DIFF
--- a/sulfur-core/Errors.ml
+++ b/sulfur-core/Errors.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Sulfur_ast
 
 type t =
-  | FailedSubtyping of Type.t * Type.t
+  | FailedUnification of Type.t * Type.t
   | FailedChecking of unit Expr.t * Type.t
   | FailedInfererence of unit Expr.t * Type.t
   | FailedInstantiation of string * Type.t

--- a/sulfur-core/Infer.ml
+++ b/sulfur-core/Infer.ml
@@ -87,6 +87,11 @@ let rec unify (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
     ->
       let* theta = unify gamma a2 a1 in
       unify theta (Context.apply theta b1) (Context.apply theta b2)
+  | Forall (a1, _K1, _A1), Forall (a2, _K2, _A2) ->
+      let a' = fresh_name () in
+      let _A1' = Type.substitute a1 (annotate_type (Unsolved a') _K1) _A1 in
+      let _A2' = Type.substitute a2 (annotate_type (Unsolved a') _K2) _A2 in
+      scoped_unsolved gamma a' (fun gamma -> unify gamma _A1' _A2')
   | _, Forall (b, _K, _B) ->
       let b' = fresh_name () in
       let _B = Type.substitute b (annotate_type (Variable b') _K) _B in

--- a/sulfur-core/Infer.ml
+++ b/sulfur-core/Infer.ml
@@ -122,16 +122,16 @@ let rec unify (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
 and instantiate (gamma : Context.t) (a : string) (_B : Type.t) :
     (Context.t, Errors.t) result =
   let* gammaL, gammaR = break_apart_at (Unsolved a) gamma in
-  let solveLeft (t : Type.t) : (Context.t, Errors.t) result =
+  let solve (t : Type.t) : (Context.t, Errors.t) result =
     let* _ = well_formed_type gammaR _B in
     Ok (List.append gammaL (Solved (a, t) :: gammaR))
   in
   match _B with
-  | Constructor _ -> solveLeft _B
-  | Variable _ -> solveLeft _B
+  | Constructor _ -> solve _B
+  | Variable _ -> solve _B
   | Unsolved b -> (
       match break_apart_at (Unsolved b) gammaL with
-      | Error _ -> solveLeft _B
+      | Error _ -> solve _B
       | Ok (gammaLL, gammaLR) ->
           let gammaL =
             List.append gammaLL (Solved (b, Unsolved a) :: gammaLR)

--- a/sulfur-core/Infer.ml
+++ b/sulfur-core/Infer.ml
@@ -94,7 +94,7 @@ let rec unify (gamma : Context.t) (_A : Type.t) (_B : Type.t) :
       scoped_unsolved gamma a' (fun gamma -> unify gamma _A1' _A2')
   | _, Forall (b, _K, _B) ->
       let b' = fresh_name () in
-      let _B = Type.substitute b (annotate_type (Variable b') _K) _B in
+      let _B = Type.substitute b (annotate_type (Unsolved b') _K) _B in
       scoped_unsolved gamma b' (fun gamma -> unify gamma _A _B)
   | Forall (a, _K, _A), _ ->
       let a' = fresh_name () in

--- a/sulfur-core/Infer.mli
+++ b/sulfur-core/Infer.mli
@@ -5,18 +5,11 @@ val well_formed_type : Context.t -> Type.t -> (unit, Errors.t) result
     with respect to the context. This function is used to partially verify the
     correctness of the algorithmic context. *)
 
-val subtype : Context.t -> Type.t -> Type.t -> (Context.t, Errors.t) result
-(** [subtype _A _B] checks the subtyping relationship between _A and _B. *)
+val unify : Context.t -> Type.t -> Type.t -> (Context.t, Errors.t) result
+(** [subtype _A _B] unifies the type _A with _B. *)
 
-val instantiateLeft :
-  Context.t -> string -> Type.t -> (Context.t, Errors.t) result
-(** [instantiateLeft a _A] instantiates the unsolved variable a with _B, such
-    that a is a subtype of _B. *)
-
-val instantiateRight :
-  Context.t -> Type.t -> string -> (Context.t, Errors.t) result
-(** [instantiateRight _A b] instantiates the unsolved variable b with _A, such
-    that _A is a subtype of b. *)
+val instantiate : Context.t -> string -> Type.t -> (Context.t, Errors.t) result
+(** [instantiate a _A] instantiates the unsolved variable a with _B. *)
 
 val check : Context.t -> unit Expr.t -> Type.t -> (Context.t, Errors.t) result
 (** [check gamma e _A] checks that the expression e has the type _A. *)


### PR DESCRIPTION
Closes #22. This PR refactors subtyping in favor of classic unification. The language does not implement nor does the compiler benefit from subtyping so I've decided to opt into unification instead.

As a tl;dr:
1. Subtyping now performs unification. The <:∀R has been refactored to be a mirror case of <:∀L.
2. Instantiation now works regardless whether an unsolved type appears on the left or right. The instantiateLeft rule is used as a base for this routine.